### PR TITLE
Feature: return logger promise in case caller needs to wait for log service to finish

### DIFF
--- a/src/__tests__/createLogger.js
+++ b/src/__tests__/createLogger.js
@@ -52,6 +52,22 @@ describe('createLogger', () => {
     Console.prototype.IsConfigValid = originalConsoleConfigCheck;
   });
 
+  it('should wait for logger to finish in promise', (done) => {
+    // delay log services
+    const delay = new Promise(resolve => setTimeout(resolve, 1000));
+    const logFinished = jest.fn(() => Promise.resolve());
+    Logger.prototype.Log = jest.fn(() => delay.then(logFinished));
+    const logMessage = new LogMessage(message);
+
+    createLogger(config)(label)(Level.INFO)(logMessage)
+      .then(() => {
+        expect(Logger.prototype.Log).toHaveBeenCalledTimes(1);
+        expect(Logger.prototype.Log).toHaveBeenCalledWith(Level.INFO, logMessage, label);
+        expect(logFinished).toHaveBeenCalledTimes(1);
+        done();
+      });
+  });
+
   it('should preset label for future logs', () => {
     const logMessage = new LogMessage(message);
 

--- a/src/__tests__/createLogger.js
+++ b/src/__tests__/createLogger.js
@@ -52,19 +52,18 @@ describe('createLogger', () => {
     Console.prototype.IsConfigValid = originalConsoleConfigCheck;
   });
 
-  it('should wait for logger to finish in promise', (done) => {
+  it('should wait for logger to finish in promise', () => {
     // delay log services
     const delay = new Promise(resolve => setTimeout(resolve, 1000));
     const logFinished = jest.fn(() => Promise.resolve());
     Logger.prototype.Log = jest.fn(() => delay.then(logFinished));
     const logMessage = new LogMessage(message);
 
-    createLogger(config)(label)(Level.INFO)(logMessage)
+    return createLogger(config)(label)(Level.INFO)(logMessage)
       .then(() => {
         expect(Logger.prototype.Log).toHaveBeenCalledTimes(1);
         expect(Logger.prototype.Log).toHaveBeenCalledWith(Level.INFO, logMessage, label);
         expect(logFinished).toHaveBeenCalledTimes(1);
-        done();
       });
   });
 

--- a/src/__tests__/logger.js
+++ b/src/__tests__/logger.js
@@ -159,7 +159,7 @@ describe('logger', () => {
       expect(Console.prototype.Log).toHaveBeenCalledWith(Level.WARN, new LogMessage(message), label);
     });
 
-    it('should wait for logger to finish in promise', (done) => {
+    it('should wait for logger to finish in promise', () => {
       // delay log services
       const delay = new Promise(resolve => setTimeout(resolve, 1000));
       const logFinished = jest.fn(() => Promise.resolve());
@@ -169,7 +169,7 @@ describe('logger', () => {
 
       const logger = new Logger(config).Label(label);
 
-      logger.Log(Level.WARN, new LogMessage(message))
+      return logger.Log(Level.WARN, new LogMessage(message))
         .then(() => {
           expect(Slack.prototype.Log).not.toHaveBeenCalled();
           expect(Fluentd.prototype.Log).toHaveBeenCalledTimes(1);
@@ -177,7 +177,6 @@ describe('logger', () => {
           expect(Console.prototype.Log).toHaveBeenCalledTimes(1);
           expect(Console.prototype.Log).toHaveBeenCalledWith(Level.WARN, new LogMessage(message), label);
           expect(logFinished).toHaveBeenCalledTimes(2);
-          done();
         });
     });
   });

--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -24,7 +24,7 @@ const createLogger = (config) => {
         message = new LogMessage(...args);
       }
 
-      labelledLogger.Log(level, message);
+      return labelledLogger.Log(level, message);
     };
 
     Object.keys(methodAlias).forEach((method) => {


### PR DESCRIPTION
should return logger (which is a Promise), in case caller needs to wait for logger to finish