### PR TITLE
feat: [APP-123584] change npm to @17live/node-logger and version v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-05-07
+
+### Changed
+- **Package Migration**: Migrated the package from `@17media/node-logger` to `@17live/node-logger`.
+- **Documentation**: Updated README badges and examples to reflect the new package name.
+- **Branding**: Updated LICENSE copyright to 17LIVE.
+
 ## [3.0.0] - 2026-04-24
 
 ### Added
@@ -72,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Basic Configuration**: Flexible config structure for multi-service logging.
 
 ---
+[3.0.1]: https://github.com/17media/node-logger/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/17media/node-logger/compare/v2.1.1...v3.0.0
 [2.1.1]: https://github.com/17media/node-logger/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/17media/node-logger/compare/v2.0.0...v2.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 17 Media
+Copyright (c) 2017-2026 17LIVE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-logger v3.0.0 🚀
 
-[![npm (scoped)](https://img.shields.io/npm/v/@17media/node-logger.svg)]()
+[![npm (scoped)](https://img.shields.io/npm/v/@17live/node-logger.svg)]()
 [![Coverage Status](https://coveralls.io/repos/github/17media/node-logger/badge.svg?branch=master)](https://coveralls.io/github/17media/node-logger?branch=master)
 
 [繁體中文版](./README.zh-TW.md)
@@ -17,7 +17,7 @@ Centralized logger for 17LIVE Node.JS projects.
 ## 🛠 Configuration
 
 ```typescript
-import { createLogger, Level } from '@17media/node-logger';
+import { createLogger, Level } from '@17live/node-logger';
 
 const loggerConfig = {
   // Shared configs (Recommended v3 style)
@@ -45,7 +45,7 @@ const loggerConfig = {
 This approach separates configuration initialization from label binding. It's ideal for multi-module projects where you want to share the same configuration factory across different parts of the application.
 
 ```typescript
-import { createLogger } from '@17media/node-logger';
+import { createLogger } from '@17live/node-logger';
 
 // 1. Initialize factory once
 const loggerFactory = createLogger(loggerConfig);
@@ -62,7 +62,7 @@ await logger.info('User logged in', { userId: 123 });
 If you are upgrading from an older version, your existing code **requires zero changes**.
 
 ```typescript
-import { createLogger } from '@17media/node-logger';
+import { createLogger } from '@17live/node-logger';
 
 // Directly create a logger instance with config and label
 const logger = createLogger(loggerConfig, 'legacy-module');

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,7 +12,7 @@ Centralized logger for 17LIVE Node.JS projects.
 ## 🛠 配置說明
 
 ```typescript
-import { createLogger, Level } from '@17media/node-logger';
+import { createLogger, Level } from '@17live/node-logger';
 
 const loggerConfig = {
   // 基礎配置 (建議 v3 寫法)
@@ -40,7 +40,7 @@ const loggerConfig = {
 這種方式將配置初始化與標籤綁定分離，適合在大型多模組應用中共享同一個工廠，並在不同模組間獲取帶有標籤的 Logger。
 
 ```typescript
-import { createLogger } from '@17media/node-logger';
+import { createLogger } from '@17live/node-logger';
 
 // 1. 初始化工廠 (只需一次)
 const loggerFactory = createLogger(loggerConfig);
@@ -57,7 +57,7 @@ await logger.info('用戶登入成功', { userId: 123 });
 如果你正從 v2 升級，現有的呼叫方式依然完全有效，不需要任何程式碼異動。
 
 ```typescript
-import { createLogger } from '@17media/node-logger';
+import { createLogger } from '@17live/node-logger';
 
 // 直接傳入配置與標籤
 const logger = createLogger(loggerConfig, 'legacy-module');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "@17media/node-logger",
-  "version": "3.0.0",
+  "name": "@17live/node-logger",
+  "version": "3.0.1",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "type": "module",
   "description": "Centralized logger for 17LIVE Node.JS projects",
   "main": "lib/index.js",
@@ -34,7 +37,7 @@
     "slack",
     "fluentd"
   ],
-  "author": "17media",
+  "author": "17live",
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Description
因為原本的 `@17media/node-logger` 遺失了帳戶權限，我們想要轉移到 `@17live/node-logger`
調整了下面兩個點
1. 更新所有的說明內容從 `@17media/node-logger` 到 `@17live/node-logger`
2. 更新了changelog 版本 `v3.0.1`
3. 更新了 License 變成 17LIVE
4. 調整 package.json `publishConfig`